### PR TITLE
Improve video preview

### DIFF
--- a/scenes/game_box/GameBoxImage.gd
+++ b/scenes/game_box/GameBoxImage.gd
@@ -32,7 +32,7 @@ func _on_app_returning(_unused: RetroHubSystemData, data: RetroHubGameData):
 func _on_media_loaded(media_data: RetroHubGameMediaData, _game_data: RetroHubGameData, types: int):
 	if game_data == _game_data:
 		if (types & RetroHubMedia.Type.VIDEO) and media_data.video:
-			n_video.stream = media_data.video
+			n_video.get_video_player().stream = media_data.video
 			if has_focus():
 				n_anim.play("Fade In Video")
 		if not n_media.texture:
@@ -61,7 +61,7 @@ func _on_GameBoxImage_focus_entered():
 	n_more_info_root.visible = true
 	n_play_container.visible = true
 	if RetroHubConfig.get_theme_config("preview_video", true):
-		if n_video.stream:
+		if n_video.get_video_player().stream:
 			n_anim.play("Fade In Video")
 		else:
 			RetroHubMedia.retrieve_media_data_async(game_data, RetroHubMedia.Type.VIDEO)
@@ -83,8 +83,8 @@ func _on_GameBoxImage_visibility_changed():
 	else:
 		RetroHubMedia.cancel_media_data_async(game_data)
 		n_media.texture = null
-		if n_video.stream:
-			n_video.stream = null
+		if n_video.get_video_player().stream:
+			n_video.get_video_player().stream = null
 
 func _on_MoreInfo_pressed():
 	emit_signal("show_game_info", game_data)

--- a/scenes/game_box/GameBoxImage.tscn
+++ b/scenes/game_box/GameBoxImage.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/controller_icons/assets/key/ctrl.png" type="Texture" id=1]
 [ext_resource path="res://addons/controller_icons/objects/TextureRect.gd" type="Script" id=2]
@@ -6,6 +6,7 @@
 [ext_resource path="res://assets/icons/more_info.svg" type="Texture" id=4]
 [ext_resource path="res://assets/icons/play.svg" type="Texture" id=5]
 [ext_resource path="res://addons/controller_icons/assets/key/enter_alt.png" type="Texture" id=6]
+[ext_resource path="res://scenes/media/Video.tscn" type="PackedScene" id=7]
 
 [sub_resource type="Animation" id=1]
 resource_name = "Fade In Video"
@@ -63,8 +64,8 @@ tracks/0/keys = {
 "update": 0,
 "values": [ Color( 1, 1, 1, 1 ) ]
 }
-tracks/1/type = "value"
-tracks/1/path = NodePath("Video:self_modulate")
+tracks/1/type = "method"
+tracks/1/path = NodePath("Video")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/imported = false
@@ -72,11 +73,13 @@ tracks/1/enabled = true
 tracks/1/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
-"update": 0,
-"values": [ Color( 1, 1, 1, 0 ) ]
+"values": [ {
+"args": [  ],
+"method": "stop"
+} ]
 }
-tracks/2/type = "method"
-tracks/2/path = NodePath("Video")
+tracks/2/type = "value"
+tracks/2/path = NodePath("Video:self_modulate")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/imported = false
@@ -84,10 +87,8 @@ tracks/2/enabled = true
 tracks/2/keys = {
 "times": PoolRealArray( 0 ),
 "transitions": PoolRealArray( 1 ),
-"values": [ {
-"args": [  ],
-"method": "stop"
-} ]
+"update": 0,
+"values": [ Color( 1, 1, 1, 0 ) ]
 }
 
 [node name="GameBoxImage" type="Button"]
@@ -107,11 +108,10 @@ margin_bottom = 106.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Video" type="VideoPlayer" parent="VBoxContainer/MediaRoot"]
+[node name="Video" parent="VBoxContainer/MediaRoot" instance=ExtResource( 7 )]
 unique_name_in_owner = true
 self_modulate = Color( 1, 1, 1, 0 )
-anchor_right = 1.0
-anchor_bottom = 1.0
+loop = true
 volume_db = -80.0
 
 [node name="Media" type="TextureRect" parent="VBoxContainer/MediaRoot"]

--- a/scenes/media/Video.gd
+++ b/scenes/media/Video.gd
@@ -1,0 +1,34 @@
+extends TextureRect
+
+export var loop := false
+export(float, -80, 24, 0.01) var volume_db := 0.0 setget set_volume_db
+
+func set_volume_db(_volume_db: float):
+	volume_db = _volume_db
+	$Container/VideoPlayer.volume_db = volume_db
+
+func _process(delta):
+	if $Container/VideoPlayer.is_playing():
+		var tex : Texture = $Container/VideoPlayer.get_video_texture()
+		texture = tex
+
+func get_video_player():
+	return $Container/VideoPlayer
+
+func play():
+	$Container/VideoPlayer.play()
+	yield(get_tree(), "idle_frame")
+	setup_ratio()
+
+func stop():
+	$Container/VideoPlayer.stop()
+
+func setup_ratio():
+	var tex : Texture = $Container/VideoPlayer.get_video_texture()
+	if tex:
+		tex.flags |= Texture.FLAG_MIPMAPS
+		$Container.ratio = tex.get_size().aspect()
+
+func _on_VideoPlayer_finished():
+	if loop:
+		$Container/VideoPlayer.play()

--- a/scenes/media/Video.tscn
+++ b/scenes/media/Video.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://scenes/media/Video.gd" type="Script" id=1]
+
+[sub_resource type="Shader" id=1]
+code = "// Source: https://kidscancode.org/godot_recipes/shaders/blur/
+
+shader_type canvas_item;
+
+uniform float blur_amount : hint_range(0, 5);
+
+void fragment() {
+	COLOR = textureLod(TEXTURE, UV, blur_amount);
+}"
+
+[sub_resource type="ShaderMaterial" id=2]
+shader = SubResource( 1 )
+shader_param/blur_amount = 5.0
+
+[node name="Video" type="TextureRect"]
+material = SubResource( 2 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+expand = true
+script = ExtResource( 1 )
+
+[node name="Container" type="AspectRatioContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+stretch_mode = 1
+
+[node name="VideoPlayer" type="VideoPlayer" parent="Container"]
+margin_left = 212.0
+margin_right = 812.0
+margin_bottom = 600.0
+
+[connection signal="finished" from="Container/VideoPlayer" to="." method="_on_VideoPlayer_finished"]


### PR DESCRIPTION
Instead of stretching video on different aspect ratios, the ratio is now preserved and a "blurred" edge is rendered. Also fix video not looping in preview.

Before:
![image](https://user-images.githubusercontent.com/6501975/220205499-221293f7-805f-4948-91c0-988b4e9d4913.png)
After:
![image](https://user-images.githubusercontent.com/6501975/220205546-3b8fa7a1-81d5-4516-845a-1270cfaf468b.png)
