### PR TITLE
Fix buttons not getting focus

### DIFF
--- a/Logic.gd
+++ b/Logic.gd
@@ -43,13 +43,14 @@ func _on_game_view_on_back_pressed():
 		await n_anim.animation_finished
 	is_on_game_view = false
 	n_anim.play("transition_seletor")
-	if last_preview:
-		print("Grabbing focus")
-		last_preview.grab_focus()
 	await n_anim.animation_finished
 	if not is_on_game_view:
 		n_game_view.free_media()
 
+func _grab_last_preview():
+	if last_preview:
+		print("Grabbing focus")
+		last_preview.grab_focus()
 
 func _on_recent_games_focus_top_element():
 	n_search_bar.grab_focus()

--- a/Theme.tscn
+++ b/Theme.tscn
@@ -187,6 +187,20 @@ tracks/6/keys = {
 "method": &"mute_media"
 }]
 }
+tracks/7/type = "method"
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/path = NodePath(".")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/keys = {
+"times": PackedFloat32Array(0.5),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"_grab_last_preview"
+}]
+}
 
 [sub_resource type="Animation" id="Animation_w3dgl"]
 resource_name = "transition_view"
@@ -263,6 +277,20 @@ tracks/5/keys = {
 "transitions": PackedFloat32Array(0.183011, 0.31864),
 "update": 0,
 "values": [Vector2(0.95, 0.95), Vector2(1, 1)]
+}
+tracks/6/type = "method"
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/path = NodePath("GameView")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/keys = {
+"times": PackedFloat32Array(0.5),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"_grab_play_button"
+}]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_u02g1"]

--- a/scenes/theme/game_view/game_view.gd
+++ b/scenes/theme/game_view/game_view.gd
@@ -101,9 +101,11 @@ func _on_data_focus_entered(time := 0.3):
 	n_data_root.focus_mode = FOCUS_ALL
 	n_keyboard_focus_btn.focus_mode = FOCUS_ALL
 	n_back.focus_neighbor_bottom = "../Media/KeyboardFocusButton"
-	n_data_root.grab_focus()
 
 	media_expanded = false
+
+func _grab_play_button():
+	n_data_root.grab_focus()
 
 
 func _on_preview_load_timer_timeout():


### PR DESCRIPTION
Weirdly, on Steam Deck the buttons were not getting any focus at all. Postponing the focusing to the animation fixes this and also makes it much more reliable.