### PR TITLE
Fix theme not adapting properly to different aspect ratios

### DIFF
--- a/Theme.tscn
+++ b/Theme.tscn
@@ -373,21 +373,21 @@ system_button = ExtResource("6_b27ka")
 
 [node name="RecentGames" parent="GameSelector/HBoxContainer/VBoxContainer/Panel/VBoxContainer/MarginContainer/Container" instance=ExtResource("6_b27ka")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(0, 0)
+custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
 button_group = SubResource("ButtonGroup_guept")
 text = "Recent"
 
 [node name="FavoriteGames" parent="GameSelector/HBoxContainer/VBoxContainer/Panel/VBoxContainer/MarginContainer/Container" instance=ExtResource("6_b27ka")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(0, 0)
+custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
 button_group = SubResource("ButtonGroup_dorua")
 text = "Favorites"
 
 [node name="Library" parent="GameSelector/HBoxContainer/VBoxContainer/Panel/VBoxContainer/MarginContainer/Container" instance=ExtResource("6_b27ka")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(0, 0)
+custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
 button_group = SubResource("ButtonGroup_ymns5")
 text = "Library"

--- a/project.godot
+++ b/project.godot
@@ -33,7 +33,6 @@ gdscript/warnings/native_method_override=1
 
 [display]
 
-window/size/viewport_height=576
 window/stretch/mode="canvas_items"
 window/stretch/aspect="keep_height"
 

--- a/scenes/theme/game_view/data_section.gd
+++ b/scenes/theme/game_view/data_section.gd
@@ -60,7 +60,7 @@ func set_bottom_focus(node_path):
 
 func _get_minimum_size():
 	if n_info_bar:
-		return n_info_bar.size
+		return Vector2(0, n_info_bar.size.y)
 	return Vector2.ZERO
 
 func populate():

--- a/scenes/theme/game_view/game_view.gd
+++ b/scenes/theme/game_view/game_view.gd
@@ -12,10 +12,16 @@ signal on_back_pressed
 @onready var n_keyboard_focus_btn := %KeyboardFocusButton
 @onready var n_preview_load_timer := %PreviewLoadTimer
 
-@onready var media_orig_rect : Rect2 = n_media_root.get_rect()
-@onready var data_orig_rect : Rect2 = n_data_root.get_rect()
+@onready var window_size := get_viewport_rect().size
+@onready var media_orig_ratio : float = n_media_root.get_rect().size.y / window_size.y
+@onready var data_orig_ratio : float = n_data_root.get_rect().size.y / window_size.y
 
 var media_expanded := false
+
+func _ready():
+	get_viewport().size_changed.connect(func():
+		window_size = get_viewport_rect().size
+	)
 
 func _input(event):
 	if not visible: return
@@ -91,8 +97,8 @@ func _on_data_focus_entered(time := 0.3):
 	var tween := create_tween()
 	tween.set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_SINE).set_parallel(true)
 
-	tween.tween_property(n_media_root, "size:y", media_orig_rect.size.y, time)
-	tween.tween_property(n_data_root, "position:y", data_orig_rect.position.y, time)
+	tween.tween_property(n_media_root, "size:y", window_size.y * media_orig_ratio, time)
+	tween.tween_property(n_data_root, "position:y", window_size.y * media_orig_ratio, time)
 
 	# Re-order media elements
 	n_media_root.animate_exit(time)

--- a/scenes/theme/side_bar/SideBarContainer.gd
+++ b/scenes/theme/side_bar/SideBarContainer.gd
@@ -41,7 +41,6 @@ func _on_system_received(data: RetroHubSystemData):
 		btn.icon = load(logo_path)
 		btn.text = " "
 	else:
-		print("Nor")
 		btn.text = data.name
 	btn.button_group = group
 	n_side_bar_container.add_child(btn)


### PR DESCRIPTION
The theme relies a lot on manual animations and size/position calculations for it's effects, which completely break on different aspect ratios. This takes into account changes to the screen size in order to fix positioning issues.

Also:
- Tweaked recent/favorites/libraries button size
- Removed debug print