### PR TITLE
Fix focus media issue, dangling search signal, and scroll systems

### DIFF
--- a/Theme.tscn
+++ b/Theme.tscn
@@ -397,6 +397,7 @@ layout_mode = 2
 mouse_filter = 1
 
 [node name="SideBar" type="ScrollContainer" parent="GameSelector/HBoxContainer/VBoxContainer/Panel/VBoxContainer/MarginContainer/Container"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 follow_focus = true
@@ -454,6 +455,7 @@ libraries = {
 
 [connection signal="pressed" from="GameSelector/HBoxContainer/VBoxContainer/Panel/VBoxContainer/MenuButton" to="." method="_on_menu_button_pressed"]
 [connection signal="focus_entered" from="GameSelector/HBoxContainer/VBoxContainer/Panel/VBoxContainer/MarginContainer/Container" to="GameSelector/HBoxContainer/VBoxContainer/Panel/VBoxContainer/MarginContainer/Container" method="_on_focus_entered"]
+[connection signal="mouse_exited" from="GameSelector/HBoxContainer/VBoxContainer/Panel/VBoxContainer/MarginContainer/Container/SideBar" to="GameSelector/HBoxContainer/VBoxContainer/Panel/VBoxContainer/MarginContainer/Container" method="_on_side_bar_mouse_exited"]
 [connection signal="search_additive_requested" from="GameSelector/HBoxContainer/VBoxContainer2/SearchBar" to="GameSelector/HBoxContainer/VBoxContainer2/GamesContainer/Logic" method="search_add"]
 [connection signal="search_requested" from="GameSelector/HBoxContainer/VBoxContainer2/SearchBar" to="GameSelector/HBoxContainer/VBoxContainer2/GamesContainer/Logic" method="search"]
 [connection signal="search_subtractive_requested" from="GameSelector/HBoxContainer/VBoxContainer2/SearchBar" to="GameSelector/HBoxContainer/VBoxContainer2/GamesContainer/Logic" method="search_sub"]

--- a/scenes/theme/game_view/game_view.gd
+++ b/scenes/theme/game_view/game_view.gd
@@ -107,6 +107,8 @@ func _on_data_focus_entered(time := 0.3):
 	n_data_root.focus_mode = FOCUS_ALL
 	n_keyboard_focus_btn.focus_mode = FOCUS_ALL
 	n_back.focus_neighbor_bottom = "../Media/KeyboardFocusButton"
+	if get_viewport().gui_get_focus_owner() != n_back:
+		n_data_root.grab_focus()
 
 	media_expanded = false
 

--- a/scenes/theme/search_bar.tscn
+++ b/scenes/theme/search_bar.tscn
@@ -54,6 +54,5 @@ one_shot = true
 
 [connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
 [connection signal="pressed" from="HBoxContainer/Icon" to="." method="_on_icon_pressed"]
-[connection signal="mouse_entered" from="HBoxContainer/LineEdit" to="." method="_on_line_edit_mouse_entered"]
 [connection signal="text_changed" from="HBoxContainer/LineEdit" to="." method="_on_line_edit_text_changed"]
 [connection signal="timeout" from="SearchDelay" to="." method="_on_search_delay_timeout"]

--- a/scenes/theme/side_bar/SideBarContainer.gd
+++ b/scenes/theme/side_bar/SideBarContainer.gd
@@ -3,6 +3,7 @@ extends VBoxContainer
 @export var system_button : PackedScene
 
 @onready var n_games_container := %GamesContainer
+@onready var n_side_bar := %SideBar
 @onready var n_side_bar_container := %SideBarContainer
 @onready var n_recent_games := %RecentGames
 @onready var n_favorite_games := %FavoriteGames
@@ -32,7 +33,7 @@ func _on_system_button_focus_entered(button: Button):
 	button.button_pressed = true
 
 func _on_system_button_focus_exited():
-	focus_on -= 1
+	focus_on = max(focus_on - 1, 0)
 
 func _on_system_received(data: RetroHubSystemData):
 	var btn := system_button.instantiate()
@@ -85,6 +86,7 @@ func focus_system_button():
 	var btn : Button = scroll_offsets[scroll_limit_idx][1]
 	if focus_on > 0: return
 	btn.button_pressed = true
+	n_side_bar.scroll_y_to(-btn.position.y)
 
 func bind_button_to_offset(btn: Button, node: Control):
 	if not node.visible:
@@ -136,3 +138,7 @@ func _on_focus_entered():
 		if btn.button_pressed:
 			btn.grab_focus()
 			return
+
+
+func _on_side_bar_mouse_exited():
+	focus_on = 0


### PR DESCRIPTION
- When selecting media previews, focus would remain on the now hidden sidebar elements. Fixes it by refocusing main screen.
- Dangling signal on search bar which was causing errors, removed.
- System sidebar elements will now scroll with main view when user is scrolling on main window.