### PR TITLE
Fix video seek bar playing sounds

### DIFF
--- a/scenes/theme/game_view/video_controls.gd
+++ b/scenes/theme/game_view/video_controls.gd
@@ -11,7 +11,12 @@ extends Panel
 @onready var n_volume_hide_timer := %VolumeHideTimer
 
 @onready var time_label_text : String = n_time_label.text
+
+@export var sound_delay : int
+
 var max_time : float
+var dragging := false
+var sound_timestamp : int
 
 func _ready():
 	n_time_timer.stop()
@@ -99,6 +104,8 @@ func _on_time_drag_started():
 	was_paused = video_player.paused
 	video_player.paused = true
 	n_time_timer.stop()
+	dragging = true
+	sound_timestamp = Time.get_ticks_msec()
 
 
 func _on_time_drag_ended(_value_changed):
@@ -109,6 +116,7 @@ func _on_time_drag_ended(_value_changed):
 	video_player.paused = was_paused
 	video_player.volume = volume
 	n_time_timer.start()
+	dragging = false
 
 func show_volume_popup():
 	n_volume_hide_timer.stop()
@@ -160,4 +168,7 @@ func _on_visibility_changed():
 
 func _on_time_value_changed(_value):
 	set_time_label()
+	if dragging and sound_timestamp < Time.get_ticks_msec():
+		RetroHubUI.play_sound(RetroHubUI.AudioKeys.SLIDER_TICK)
+		sound_timestamp = Time.get_ticks_msec() + sound_delay
 

--- a/scenes/theme/game_view/video_controls.tscn
+++ b/scenes/theme/game_view/video_controls.tscn
@@ -17,6 +17,7 @@ grow_horizontal = 2
 grow_vertical = 0
 size_flags_horizontal = 3
 script = ExtResource("1_m88rk")
+sound_delay = 50
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 1
@@ -40,7 +41,7 @@ texture_focused = ExtResource("4_1x7om")
 ignore_texture_size = true
 stretch_mode = 5
 
-[node name="Time" type="HSlider" parent="HBoxContainer"]
+[node name="Time" type="HSlider" parent="HBoxContainer" groups=["rh_no_sound"]]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -76,7 +77,7 @@ anchor_right = 1.0
 offset_top = -150.0
 grow_horizontal = 2
 
-[node name="VolumeSlider" type="VSlider" parent="HBoxContainer/Sound/VolumePopup"]
+[node name="VolumeSlider" type="VSlider" parent="HBoxContainer/Sound/VolumePopup" groups=["rh_no_sound"]]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = -1


### PR DESCRIPTION
Because the seek bar is updated with the video playback, it played a tick sound every frame. This fixes it by manually managing UI sounds in this scenario.

Additionally, UI sound was disabled for the volume bar.