### PR TITLE
Fix achievement icon loading not being lazy

### DIFF
--- a/scenes/theme/game_view/Achievements.gd
+++ b/scenes/theme/game_view/Achievements.gd
@@ -193,10 +193,13 @@ func load_achievements():
 	for achievement in game_info.achievements:
 		var data := achievement_data_scene.instantiate()
 		n_achievement_cnt.add_child(data)
-		data.set_data(game_info, achievement)
 		instance_count += 1
 		# Instancing objects stalls the main thread. Multithreading cannot solve this sadly.
 		# So, we only instance 3 objects per frame, to prevent visible stutters.
 		if instance_count > 2:
 			instance_count = 0
 			await get_tree().process_frame
+	var idx = 0
+	for child in n_achievement_cnt.get_children():
+		child.set_data(game_info, game_info.achievements[idx])
+		idx += 1

--- a/scenes/theme/game_view/achievements/achievement_data.gd
+++ b/scenes/theme/game_view/achievements/achievement_data.gd
@@ -36,29 +36,29 @@ func _ready():
 func _process(_delta):
 	# Handle behavior differently if currently loaded media or not
 	if media_loaded:
-		check_unload_media(global_position.y)
+		check_unload_media()
 	else:
-		check_load_media(global_position.y)
+		check_load_media()
 
 # Check if we should unload media
-func check_unload_media(y: float):
+func check_unload_media():
 	# Unload if we leave the limits
-	var min_y = global_position.y - 50
-	if y + size.y < min_y or y > max_y:
+	var parent_y = get_parent().position.y
+	if parent_y + position.y + size.y < -50 or global_position.y > max_y:
 		media_loaded = false
 		n_icon.texture = null
 
-func check_load_media(y: float):
+func check_load_media():
 	# Load if we are inside the limits
-	var min_y = global_position.y - 50
-	if y + size.y >= min_y and y <= max_y:
+	var parent_y = get_parent().position.y
+	if parent_y + position.y + size.y >= -50 and global_position.y <= max_y:
 		media_loaded = true
 		n_icon.texture = await achievement.load_icon()
 
 func set_data(info: RetroAchievementsIntegration.GameInfo, achievement: RetroAchievementsIntegration.Achievement):
 	self.achievement = achievement
 	set_process(true)
-	
+
 	n_title.text = achievement.title
 	n_description.text = achievement.description
 


### PR DESCRIPTION
Due to how nodes are instantiated and reordered by the parent container, all nodes were at position "0", thus they all loaded icons in the beginning. This fixes it by deferring that step to a later stage where nodes are positioned properly.>

The logic for detecting media unloads on the upper side was also broken, and this fixes the math for that as well.