### PR TITLE
Remove video stream max length hack

### DIFF
--- a/scenes/theme/game_view/video_controls.gd
+++ b/scenes/theme/game_view/video_controls.gd
@@ -64,9 +64,7 @@ var video_player : VideoStreamPlayer:
 		setup()
 
 func setup():
-	# Hack to find video length on kidrigger's addon.
-	video_player.stream_position = -1
-	max_time = video_player.stream_position
+	max_time = video_player.get_stream_length()
 	video_player.stream_position = 0
 
 	n_play_pause.button_pressed = false


### PR DESCRIPTION
The new FFmpeg backend properly implements Godot's `get_stream_length` function to know this information.